### PR TITLE
Various global style changes

### DIFF
--- a/src/components/drawer/styles/_drawer.scss
+++ b/src/components/drawer/styles/_drawer.scss
@@ -68,7 +68,7 @@ $drawer-width: 410px;
       padding: 80px 46px 0;
 
       p.continue {
-        text-align: center;
+        text-align: left;
 
         a.btn-continue {
           margin-top:20px;

--- a/src/components/steps/styles/_steps.scss
+++ b/src/components/steps/styles/_steps.scss
@@ -138,7 +138,7 @@ button.step-close-button {
 
     .step-title {
       font-family: $salesforcesans;
-      font-weight: bold;
+      font-weight: normal;
       font-size: 16px;
       line-height: 20px;
       opacity: 0;
@@ -216,8 +216,9 @@ button.step-close-button {
     }
 
     p {
-      font-size:16px;
-      padding: 0 22%;
+      font-size: 22px;
+      padding: 0 12%;
+      font-weight: bold;
     }
 
     .btn {

--- a/src/styles/__buttons.scss
+++ b/src/styles/__buttons.scss
@@ -1,7 +1,7 @@
 @import "_base";
 
 $button-font-size: 14px;
-$button-rounded-radius: 24px;
+$button-rounded-radius: 4px;
 
 button, a {
   &:hover, &:active, &:focus {

--- a/src/styles/__flyout.scss
+++ b/src/styles/__flyout.scss
@@ -1,6 +1,6 @@
 .flyout {
   padding: 25px;
-  background: rgba($color-continue-hover, .8);
+  background: rgba($color-background-flyout, 1);
   width: 400px;
   position: absolute;
   bottom: 25px;

--- a/src/styles/__forms.scss
+++ b/src/styles/__forms.scss
@@ -18,13 +18,13 @@
 
 @keyframes borderActive {
   0% {
-    box-shadow: 0 0 0 0 rgba(#00ffff, .2);
+    box-shadow: 0 0 0 0 rgba($color-marketing-cloud-orange, .2);
   }
   50% {
-    box-shadow: 0 0 0 8px rgba($color-salesforce-blue, .3);
+    box-shadow: 0 0 0 8px rgba($color-marketing-cloud-orange, 1);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(#00ffff, .2);
+    box-shadow: 0 0 0 0 rgba($color-marketing-cloud-orange, .2);
   }
 }
 

--- a/src/styles/__variables.scss
+++ b/src/styles/__variables.scss
@@ -46,6 +46,7 @@ $color-background-gray: #cccccc;
 $color-background-gray-medium: #F7F7F7;
 $color-background-black: #212121;
 $color-background-white: #ffffff;
+$color-background-flyout: #e67300;
 
 /* Text Colors */
 $text-color-white: #ffffff;


### PR DESCRIPTION
- Step text is now `normal` instead of `bold`
- Success text (at end of all steps) is now 22px and bold with less left/right padding
- Buttons now have 4px corner radius instead of 24px
- Background of flyouts is now non-transparent orange
- Button pulse color is now orange instead of blue